### PR TITLE
Main pararalleflow deadlock tests

### DIFF
--- a/src/test/java/executor/service/service/impl/parallel/DeadlockParallelFlowExecutorServiceImplTest.java
+++ b/src/test/java/executor/service/service/impl/parallel/DeadlockParallelFlowExecutorServiceImplTest.java
@@ -1,0 +1,47 @@
+package executor.service.service.impl.parallel;
+
+import executor.service.model.ProxyConfigHolder;
+import executor.service.model.Scenario;
+import executor.service.service.ExecutionService;
+import executor.service.service.ParallelFlowExecutorService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@ExtendWith(SpringExtension.class)
+class DeadlockParallelFlowExecutorServiceImplTest {
+
+    @Autowired
+    ParallelFlowExecutorService service;
+
+    @MockBean
+    ScenarioSourceQueue scenarioSourceQueue;
+
+    @MockBean
+    ExecutionService executionService;
+
+    @MockBean
+    ProxySourceQueue proxySourceQueue;
+
+
+    @Test
+    public  void whenCatchRuntimeError() {
+
+        when(scenarioSourceQueue.getScenario()).thenReturn(new Scenario()).thenThrow(new RuntimeException()).thenReturn(new Scenario());
+        when(proxySourceQueue.getProxy()).thenReturn(new ProxyConfigHolder()).thenReturn(new ProxyConfigHolder()).thenReturn(new ProxyConfigHolder());
+
+        //verify(executionService, times(3)).execute();
+        verify(service, times(3)).execute();
+
+
+
+    }
+
+
+}

--- a/src/test/java/executor/service/service/impl/parallel/ProxySourceQueueTest.java
+++ b/src/test/java/executor/service/service/impl/parallel/ProxySourceQueueTest.java
@@ -2,9 +2,20 @@ package executor.service.service.impl.parallel;
 
 import executor.service.model.ProxyConfigHolder;
 import executor.service.model.QueueData;
+import executor.service.service.ItemHandler;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.*;
 
 /**
  * Test class for testing the functionality of the {@code ItemQueue} class.
@@ -18,6 +29,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 public class ProxySourceQueueTest {
 
+    private ProxySourceQueueHandler handler;
+    private ItemHandler itemHandler;
+    private Consumer<ProxyConfigHolder> itemHandlerConsumer;
+    private ProxySourceQueue queue;
+
+    @BeforeEach
+    void setUp() {
+        handler = Mockito.mock(ProxySourceQueueHandler.class);
+        itemHandler = Mockito.mock(ItemHandler.class);
+        itemHandlerConsumer = Mockito.mock(Consumer.class);
+        queue = new ProxySourceQueue(new QueueData(5));
+    }
+
     @Test
     void testPutAndGetProxy() {
         var proxy = new ProxyConfigHolder();
@@ -30,4 +54,36 @@ public class ProxySourceQueueTest {
 
         assertEquals(proxy, result);
     }
+
+    @Test
+    void testOnDeadlockWhenHandlerCrash() throws ExecutionException, InterruptedException, TimeoutException {
+        ProxyConfigHolder holder = new ProxyConfigHolder();
+
+        doAnswer(invocation -> {
+                    queue.putProxy(holder);
+                    queue.putProxy(holder);
+                    return null;
+                }).when(handler).run();
+
+        when(handler.getProxy()).thenReturn(holder).thenThrow(new RuntimeException()).thenReturn(holder);
+
+        FutureTask<List<ProxyConfigHolder>> task = new FutureTask(
+                () -> {
+                    List<ProxyConfigHolder> list = new ArrayList<>();
+                    list.add(queue.getProxy());
+                    try {
+                        list.add(queue.getProxy());
+                    } catch (Exception e){
+                    }
+                    list.add(queue.getProxy());
+                    return list;
+                }
+        );
+        List<ProxyConfigHolder> proxyConfigHolders = task.get(2l, TimeUnit.SECONDS);
+
+        assertFalse(proxyConfigHolders.isEmpty());
+        assertEquals(2, proxyConfigHolders.size());
+
+    }
+
 }


### PR DESCRIPTION
Find some problems with ParallelFlowExecutorService and queues

1. ParallelFlowExecutorService doesn't shutdown from the main thread;
2. When queues throw  RuntimeException  app all fall down.
3. If queues catch RuntimeException on put operations it's block